### PR TITLE
Ppu scrolling fix

### DIFF
--- a/src/extern_structs.h
+++ b/src/extern_structs.h
@@ -233,13 +233,13 @@ typedef struct {
 	uint8_t pt_hi_latch;
 	uint16_t pt_lo_shift_reg; /* Stores a 16 pixels in the pipeline - 1st 8 pixels to be rendered are in lowest byte */
 	uint16_t pt_hi_shift_reg;
+	uint8_t at_lo_shift_reg; /* Matches lowest 8 bits for the pattern table shift register */
+	uint8_t at_hi_shift_reg;
 	uint8_t nt_byte; /* NT byte that is rendered 16 PPU cycles later */
 	uint8_t at_latch; /* AT byte that is rendered 16 PPU cycles later */
 	uint8_t at_current; /* AT byte for pixels 1 - 8 in pipeline */
-	uint8_t at_next; /* AT byte for pixels 9 - 16 in pipeline */
 
 	uint16_t nt_addr_tmp; /* Address used to generate nt byte */
-	uint16_t nt_addr_next; /* Next tile address for pixels 9 -16 in pipeline */
 	uint16_t nt_addr_current; /* Current tile address for pixels 1 - 8 in pipeline */
 
 	unsigned mirroring; // 0 = Horz, 1 = vert, 4 = 4 screen

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -743,7 +743,7 @@ static void render_pixel(Ppu2C02 *p)
 	// hold 0 and the mux will select those incorrect bits
 	// Instead we reload the shift registers with new attribute data
 	// when the fine_x will select a new tile to render e.g. moving from
-	// pixels 1-8 in the pipeline to 8-16
+	// pixels 1-8 in the pipeline to 9-16
 	// They are then reloaded evey 8 cycles after that
 	// (alternatively you can mux w/ fine_x as long as you don't shift
 	// out the attribute shift registers)

--- a/src/ppu.c
+++ b/src/ppu.c
@@ -1053,8 +1053,8 @@ void clock_ppu(Ppu2C02* p, Cpu6502* cpu, Display* nes_screen, const bool no_logg
 					p->at_current = p->at_next;
 					p->at_next = p->at_latch;
 					/* Load latched values into upper byte of shift regs */
-					p->pt_lo_shift_reg |= (uint16_t) (p->pt_lo_latch << 8);
-					p->pt_hi_shift_reg |= (uint16_t) (p->pt_hi_latch << 8);
+					p->pt_lo_shift_reg |= (uint16_t) (p->pt_lo_latch << (8 - p->fine_x));
+					p->pt_hi_shift_reg |= (uint16_t) (p->pt_hi_latch << (8 - p->fine_x));
 					/* Used for palette calculations */
 					p->nt_addr_current = p->nt_addr_next;
 					p->nt_addr_next = p->nt_addr_tmp;
@@ -1084,8 +1084,8 @@ void clock_ppu(Ppu2C02* p, Cpu6502* cpu, Display* nes_screen, const bool no_logg
 					/* Load latched values into upper byte of shift regs */
 					p->pt_hi_shift_reg >>= 8;
 					p->pt_lo_shift_reg >>= 8;
-					p->pt_hi_shift_reg |= (uint16_t) (p->pt_hi_latch << 8);
-					p->pt_lo_shift_reg |= (uint16_t) (p->pt_lo_latch << 8);
+					p->pt_hi_shift_reg |= (uint16_t) (p->pt_hi_latch << (8 - p->fine_x));
+					p->pt_lo_shift_reg |= (uint16_t) (p->pt_lo_latch << (8 - p->fine_x));
 					p->at_current = p->at_next; // at_current is 1st loaded w/ garbage
 					p->at_next = p->at_latch;
 					p->nt_addr_current = p->nt_addr_next;
@@ -1144,8 +1144,8 @@ void clock_ppu(Ppu2C02* p, Cpu6502* cpu, Display* nes_screen, const bool no_logg
 					/* Load latched values into upper byte of shift regs */
 					p->pt_hi_shift_reg >>= 8;
 					p->pt_lo_shift_reg >>= 8;
-					p->pt_hi_shift_reg |= (uint16_t) (p->pt_hi_latch << 8);
-					p->pt_lo_shift_reg |= (uint16_t) (p->pt_lo_latch << 8);
+					p->pt_hi_shift_reg |= (uint16_t) (p->pt_hi_latch << (8 - p->fine_x));
+					p->pt_lo_shift_reg |= (uint16_t) (p->pt_lo_latch << (8 - p->fine_x));
 					p->at_current = p->at_next; // at_current is 1st loaded w/ garbage
 					p->at_next = p->at_latch;
 					p->nt_addr_current = p->nt_addr_next;


### PR DESCRIPTION
cNES now correctly scrolls the background tiles. Pretty much achieved in a similar way to how the NES hardware does it, using a 8x1 mux to select the correct bit from both background shift registers.

One potential issue of this PR is that the sprite 0 lookahead hit function will need to be modified in a similar way (99% sure of this). That change will come after this merge as the "ppu_scrolling_fix" branch has completed what it was set out to, fixing the palette issues from correctly scrolling the background.